### PR TITLE
build: create multi-arch Docker images

### DIFF
--- a/.github/workflows/publish-to-hub-docker.yml
+++ b/.github/workflows/publish-to-hub-docker.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           images: johannesjo/super-productivity
 
+      -  name: Set up Docker Buildx
+         uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -43,3 +46,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
+          platforms: linux/amd64, linux/arm64, linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ### build ###
 
 # base image
-FROM node:20 as build
+FROM --platform=$BUILDPLATFORM node:20 as build
 
 # add app
 COPY . /app
@@ -26,7 +26,10 @@ RUN npm run buildFrontend:prodWeb
 ### serve ###
 
 # base image
-FROM nginx:1-alpine
+# --platform=$TARGETPLATFORM is redundant and docker will raise a warning,
+# but it makes it clearer that the target platform might be different from the
+# build platform
+FROM --platform=$TARGETPLATFORM nginx:1-alpine
 
 # environmental variables
 ENV PORT=80


### PR DESCRIPTION
Create multi-arch Docker images. Currently built platforms are:

* linux/amd64
* linux/arm64
* linux/arm/v7